### PR TITLE
Add config support for inline markup

### DIFF
--- a/shml.js
+++ b/shml.js
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 SHML = {
-  parseInlineMarkup: function(str) {
+  parseInlineMarkup: function(str, config = {properties: []}) {
     let array = str.split(/(`|\$\$)([\S\s]*?)(\1)/g), result = {toHTML: () => result._value, _value: ''}, code = false, escaped = false;
     array.forEach(object => {
       if(object === '`') code = !code, object = '';

--- a/shml.js
+++ b/shml.js
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 SHML = {
-  parseInlineMarkup: function(str, config = {properties: []}) {
+  parseInlineMarkup: function(str, config = {}) {
     let array = str.split(/(`|\$\$)([\S\s]*?)(\1)/g), result = {toHTML: () => result._value, _value: ''}, code = false, escaped = false;
     array.forEach(object => {
       if(object === '`') code = !code, object = '';


### PR DESCRIPTION
Add the ability to configure inline markup. This is currently unused, but in the future it could be for custom formatting/styles. It could also let the user specify if same-tab links should open in `_self` or `_top`.